### PR TITLE
Lock Virtus gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,3 @@ source :rubygems
 
 gemspec
 
-gem 'virtus', :git => 'https://github.com/solnic/virtus'
-
-# RUBY_VERSION ~> "1.9.0"
-# gem "debugger"
-
-# RUBY_VERSION ~> "1.8.0"
-# gem "ruby-debug"
-# gem "linecache", "0.43"

--- a/json-schematized.gemspec
+++ b/json-schematized.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "multi_json", "~> 1.0"
   s.add_runtime_dependency "activesupport"
-  s.add_runtime_dependency "virtus"
+  s.add_runtime_dependency "virtus", '~> 0.5'
 
   s.add_development_dependency "json", "~> 1.4"
   s.add_development_dependency "rspec", ">= 2.6"


### PR DESCRIPTION
This is a fix for Issue #2 : the API for Virtus has changed from 0.5.x to 1.x.
I'm not sure exactly what's changed, or what's needed to make this work with the newer version of Virtus,
but this at least gets things working again from clean installs :)
